### PR TITLE
Fix export syntax

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,2 @@
 export * from './core';
-export type * from './types';
+export * from './types';

--- a/types/core/index.d.ts
+++ b/types/core/index.d.ts
@@ -1,2 +1,2 @@
 export * from './core';
-export type * from './types';
+export * from './types';


### PR DESCRIPTION
## Summary
- correct the export syntax for type re-exports

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428f4e6d3483268a0d8c2ee7d54c5f