### PR TITLE
Fix CI node matrix and install flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     - name: Run tests
       run: pnpm run test


### PR DESCRIPTION
## Summary
- test on Node 18 and Node 20 only
- install dependencies with `--frozen-lockfile`

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684292febc3c8326863714d657d04dcb